### PR TITLE
Display configurable project path on issue cards

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,6 +64,7 @@
     import ScopedLabelsDropdowns from './components/ScopedLabelsDropdowns.vue';
     import TodoList from './components/TodoList.vue';
     import { useRenderProjectAvatarIssues } from './composables/useRenderProjectAvatarIssues';
+    import { useRenameProjectInIssueBoards } from './composables/useRenameProjectInIssueBoards';
     import { useHighlightMyIssuesMrs } from './composables/useHighlightMyIssuesMrs';
     import { useDimDraftMrs } from './composables/useDimDraftMrs';
     import {
@@ -77,6 +78,7 @@
     const { getSetting } = useExtensionStore();
     usePersistentFilters();
     const { render: renderProjectAvatars } = useRenderProjectAvatarIssues();
+    const { rename: renameProjectIssueBoards } = useRenameProjectInIssueBoards();
     const { highlight: highlightMyIssuesMrs } = useHighlightMyIssuesMrs();
     const { dim: dimDraftMrs } = useDimDraftMrs();
 
@@ -118,6 +120,7 @@
         window.addEventListener('message', (event) => {
             if (event.data.type === 'browser-request-completed' && !event.data.data.url.includes('is_custom=1')) {
                 renderProjectAvatars();
+                renameProjectIssueBoards();
                 highlightMyIssuesMrs(gitlabUsername.value);
                 dimDraftMrs();
 

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -133,6 +133,17 @@
 
                                                     @input="onInput(preference.key, $event)"
                                                 >
+
+                                                <input
+                                                    v-if="typeof preference.defaultValue === 'number'"
+
+                                                    class="form-control gl-border-gray-200"
+                                                    style="margin-left: 24px; margin-bottom: 8px; width: 20%;"
+                                                    type="number"
+                                                    :value="getSetting(preference.key, preference.defaultValue)"
+
+                                                    @input="onInput(preference.key, $event)"
+                                                >
                                             </button>
                                         </li>
                                     </template>
@@ -182,6 +193,7 @@
         mdiMapMarkerOutline,
         mdiScriptTextOutline,
         mdiStarOutline,
+        mdiFormTextbox,
     } from '@mdi/js';
     import { onClickOutside } from '@vueuse/core';
     import showdown from 'showdown'; //eslint-disable-line
@@ -216,7 +228,7 @@
         icon: string;
         isGitlabIcon: boolean;
         iconClassName: string;
-        defaultValue: boolean | string;
+        defaultValue: boolean | string | number;
     }
 
     const {
@@ -403,6 +415,15 @@
                 isGitlabIcon: true,
                 iconClassName: '',
                 defaultValue: '',
+            },
+            {
+                label: 'Display project path in issue cards (board)',
+                title: 'Select how many levels of the project path to display on issue cards',
+                key: Preference.ISSUE_BOARDS_RENAME_PROJECT,
+                icon: mdiFormTextbox,
+                isGitlabIcon: false,
+                iconClassName: '',
+                defaultValue: 0,
             },
         ],
         'Merge Requests': [

--- a/src/composables/useRenameProjectInIssueBoards.ts
+++ b/src/composables/useRenameProjectInIssueBoards.ts
@@ -1,0 +1,39 @@
+import { useExtractProjectPaths } from './useExtractProjectPaths';
+import { Preference, useExtensionStore } from '../store';
+import { debounce } from 'lodash-es';
+import { computed } from 'vue';
+
+function getPathFromLevel(str: string, level: number) {
+  const parts = str.split('/');
+  const start = Math.max(0, parts.length - 1 - level);
+  return parts.slice(start).join('/');
+}
+
+export function useRenameProjectInIssueBoards() {
+    const { getSetting } = useExtensionStore();
+    const { extract: extractProjectPaths } = useExtractProjectPaths();
+
+    const projectNameParts = computed(() => getSetting(Preference.ISSUE_BOARDS_RENAME_PROJECT, 0) as number);
+
+    function injectProjectName(projectPath: string) {
+        if(projectNameParts.value <= 0) return;
+        if(!window.location.href.includes('boards')) return;
+
+        const targetElements = document.querySelectorAll(`li.board-card span[title="${projectPath}"]`);
+        targetElements.forEach((targetElement) => {
+            targetElement.textContent = getPathFromLevel(projectPath, projectNameParts.value);
+        });
+        
+    }
+
+    function injectProjectNames() {
+        const paths = extractProjectPaths();
+        paths.forEach((path) => {
+            injectProjectName(path);
+        });
+    }
+    
+    return {
+        rename: debounce(injectProjectNames, 500),
+    };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,6 +27,7 @@ export const enum Preference {
     ISSUE_VALIDATE_MISSING_WEIGHT = 'issue_validate_missing_weight',
     ISSUE_VALIDATE_UNRESOLVED_THREADS = 'issue_validate_unresolved_threads',
     ISSUE_REQUIRED_SCOPED_LABELS = 'issue_required_scoped_labels',
+    ISSUE_BOARDS_RENAME_PROJECT = 'issue_boards_rename_project',
 
     MR_HIGHLIGHT_MINE = 'mr_highlight_mine',
     MR_HIGHLIGHT_MY_APPROVALS = 'mr_highlight_my_approvals',


### PR DESCRIPTION
This update allows users to replace the default project name shown on issue cards with a customizable path leading up to the top-level group. The user specifies how many levels up the group hierarchy to include.

Example (project path: maingroup → subgroup1 → subgroup2 → project):

- Input 0 (default): project

- Input 1: subgroup2/project

- Input 2: subgroup1/subgroup2/project

- Input 3+: maingroup/subgroup1/subgroup2/project